### PR TITLE
Adds missing PROJECT_PREFIX to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ APP_KEY=
 APP_DEBUG=false
 APP_URL=http://localhost
 
+PROJECT_PREFIX="BSS"
+
 SESSION_DOMAIN=localhost
 SESSION_SECURE_COOKIE=true
 


### PR DESCRIPTION
The `PROJECT_PREFIX` is missing from the `.env.example` file. This commit adds it.